### PR TITLE
Removed the "WHY?"s from the manual

### DIFF
--- a/data_layout.tex
+++ b/data_layout.tex
@@ -48,7 +48,7 @@ Data is laid out as  \(u_{ijk}^e = u(i,j,k,e)\) \\
    enddo
 \end{verbatim}
 
-   which is equivalent but superior (WHY?) to:
+   which is equivalent but superior to:
 
 \begin{verbatim}
    do e=1,nelv
@@ -63,7 +63,7 @@ Data is laid out as  \(u_{ijk}^e = u(i,j,k,e)\) \\
 \end{verbatim}
 
 
-   which is equivalent but vastly superior (WHY?) to:
+   which is equivalent but vastly superior to:
 
 \begin{verbatim}
    do i=1,nx1


### PR DESCRIPTION
The WHY's do not need to be there. We can bring it up how to properly address this in the manual during a user meeting or issue conversation.